### PR TITLE
Add Medicine+ Patch

### DIFF
--- a/1.2/Patches/Patches_DR_MedicinePlus.xml
+++ b/1.2/Patches/Patches_DR_MedicinePlus.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+  <!-- ====== Compatability Patch ==================== -->
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Medicines+</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <success>Always</success>
+      <operations>
+        <li Class="PatchOperationAddModExtension">
+          <xpath>/Defs/ThingDef[defName="PoppyLatex" or defName="SSalts" or defName="ThornWeedNeedle" or defName="Upper" or defName="ThornWeedExtract" or defName="Morphine" or defName="Heroin"]</xpath>
+          <value>
+            <li Class="MSPainless.MSPainDrug">
+              <ManagesPain>true</ManagesPain>
+            </li>
+          </value>
+        </li>
+      </operations>
+    </match>
+  </Operation>
+</Patch>


### PR DESCRIPTION
This PR adds the various pain medications from Medicines+ by Atlas. Currently included in this patch are opium, smelling salts, thornweed needle, upper, thorweed serum, morphine, and heroin.